### PR TITLE
Add license field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Option parser with generated usage and commands",
   "version": "1.8.1",
   "author": "Heather Arthur <fayearthur@gmail.com>",
+  "license": "MIT",
   "scripts": {
     "test": "./node_modules/.bin/nodeunit test/*.js"
   },


### PR DESCRIPTION
From [npm documentation](https://docs.npmjs.com/files/package.json#license):

> You should specify a license for your package so that people know how they are permitted to use it, and any restrictions you're placing on it.
